### PR TITLE
General code cleanup

### DIFF
--- a/src/main/java/eu/endermite/censura/Filter.java
+++ b/src/main/java/eu/endermite/censura/Filter.java
@@ -66,10 +66,10 @@ public class Filter {
     }
 
     public static boolean detect(String message, FilterStrength mode) {
-        return detectPhrases(message, FilterStrength.SEVERE) ||
-                detectPhrases(normalizedString(message), FilterStrength.SEVERE) ||
-                detectPhrases(noRepeatChars(message), FilterStrength.SEVERE) ||
-                detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.SEVERE);
+        return detectPhrases(message, mode) ||
+                detectPhrases(normalizedString(message), mode) ||
+                detectPhrases(noRepeatChars(message), mode) ||
+                detectPhrases(noRepeatChars(normalizedString(message)), mode);
     }
 
     public static boolean filter(String message, Player player) {

--- a/src/main/java/eu/endermite/censura/Filter.java
+++ b/src/main/java/eu/endermite/censura/Filter.java
@@ -27,19 +27,25 @@ public class Filter {
         return message;
     }
 
-    public static boolean detectPhrases(String string, String mode) {
+    public static boolean detectPhrases(String string, FilterStrength mode) {
         List<String> exceptions = null;
         List<String> matches = null;
-        if (mode.equalsIgnoreCase("lite")) {
-            exceptions = Censura.getCachedConfig().getLiteExceptions();
-            matches = Censura.getCachedConfig().getLiteMatches();
-        } else if (mode.equalsIgnoreCase("normal")) {
-            exceptions = Censura.getCachedConfig().getNormalExceptions();
-            matches = Censura.getCachedConfig().getNormalMatches();
-        } else if (mode.equalsIgnoreCase("severe")) {
-            exceptions = Censura.getCachedConfig().getSevereExceptions();
-            matches = Censura.getCachedConfig().getSevereMatches();
+
+        switch (mode) {
+            case SEVERE:
+                exceptions = Censura.getCachedConfig().getSevereExceptions();
+                matches = Censura.getCachedConfig().getSevereMatches();
+                break;
+            case NORMAL:
+                exceptions = Censura.getCachedConfig().getNormalExceptions();
+                matches = Censura.getCachedConfig().getNormalMatches();
+                break;
+            case LITE:
+                exceptions = Censura.getCachedConfig().getLiteExceptions();
+                matches = Censura.getCachedConfig().getLiteMatches();
+                break;
         }
+
         if (matches == null) {
             return false;
         }
@@ -68,32 +74,32 @@ public class Filter {
             return false;
         }
 
-        if (detectPhrases(message, "severe") || detectPhrases(normalizedString(message), "severe")) {
+        if (detectPhrases(message, FilterStrength.SEVERE) || detectPhrases(normalizedString(message), FilterStrength.SEVERE)) {
             doActions(Censura.getCachedConfig().getSeverePunishments(), player);
             return true;
         }
 
-        if (detectPhrases(noRepeatChars(message), "severe") || detectPhrases(noRepeatChars(normalizedString(message)), "severe")) {
+        if (detectPhrases(noRepeatChars(message), FilterStrength.SEVERE) || detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.SEVERE)) {
             doActions(Censura.getCachedConfig().getSeverePunishments(), player);
             return true;
         }
 
-        if (detectPhrases(message, "normal") || detectPhrases(normalizedString(message), "normal")) {
+        if (detectPhrases(message, FilterStrength.NORMAL) || detectPhrases(normalizedString(message), FilterStrength.NORMAL)) {
             doActions(Censura.getCachedConfig().getNormalPunishments(), player);
             return true;
         }
 
-        if (detectPhrases(noRepeatChars(message), "normal") || detectPhrases(noRepeatChars(normalizedString(message)), "normal")) {
+        if (detectPhrases(noRepeatChars(message), FilterStrength.NORMAL) || detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.NORMAL)) {
             doActions(Censura.getCachedConfig().getNormalPunishments(), player);
             return true;
         }
 
-        if (detectPhrases(message, "lite") || detectPhrases(normalizedString(message), "lite")) {
+        if (detectPhrases(message, FilterStrength.LITE) || detectPhrases(normalizedString(message), FilterStrength.LITE)) {
             doActions(Censura.getCachedConfig().getLitePunishments(), player);
             return true;
         }
 
-        if (detectPhrases(noRepeatChars(message), "lite") || detectPhrases(noRepeatChars(normalizedString(message)), "lite")) {
+        if (detectPhrases(noRepeatChars(message), FilterStrength.LITE) || detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.LITE)) {
             doActions(Censura.getCachedConfig().getLitePunishments(), player);
             return true;
         }
@@ -102,27 +108,27 @@ public class Filter {
 
     public static boolean filterNoActions(String message) {
 
-        if (detectPhrases(message, "severe") || detectPhrases(normalizedString(message), "severe")) {
+        if (detectPhrases(message, FilterStrength.SEVERE) || detectPhrases(normalizedString(message), FilterStrength.SEVERE)) {
             return true;
         }
 
-        if (detectPhrases(noRepeatChars(message), "severe") || detectPhrases(noRepeatChars(normalizedString(message)), "severe")) {
+        if (detectPhrases(noRepeatChars(message), FilterStrength.SEVERE) || detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.SEVERE)) {
             return true;
         }
 
-        if (detectPhrases(message, "normal") || detectPhrases(normalizedString(message), "normal")) {
+        if (detectPhrases(message, FilterStrength.NORMAL) || detectPhrases(normalizedString(message), FilterStrength.NORMAL)) {
             return true;
         }
 
-        if (detectPhrases(noRepeatChars(message), "normal") || detectPhrases(noRepeatChars(normalizedString(message)), "normal")) {
+        if (detectPhrases(noRepeatChars(message), FilterStrength.NORMAL) || detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.NORMAL)) {
             return true;
         }
 
-        if (detectPhrases(message, "lite") || detectPhrases(normalizedString(message), "lite")) {
+        if (detectPhrases(message, FilterStrength.LITE) || detectPhrases(normalizedString(message), FilterStrength.LITE)) {
             return true;
         }
 
-        if (detectPhrases(noRepeatChars(message), "lite") || detectPhrases(noRepeatChars(normalizedString(message)), "lite")) {
+        if (detectPhrases(noRepeatChars(message), FilterStrength.LITE) || detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.LITE)) {
             return true;
         }
         return false;
@@ -158,4 +164,9 @@ public class Filter {
         }
     }
 
+    public enum FilterStrength {
+        SEVERE,
+        NORMAL,
+        LITE
+    }
 }

--- a/src/main/java/eu/endermite/censura/Filter.java
+++ b/src/main/java/eu/endermite/censura/Filter.java
@@ -29,7 +29,7 @@ public class Filter {
 
     public static boolean detectPhrases(String string, FilterStrength mode) {
         List<String> exceptions = null;
-        List<String> matches = null;
+        List<Pattern> matches = null;
 
         switch (mode) {
             case SEVERE:
@@ -56,8 +56,8 @@ public class Filter {
             }
         } catch (NullPointerException ignored) {}
 
-        for (String match : matches) {
-            Matcher m = Pattern.compile(match).matcher(string);
+        for (Pattern match : matches) {
+            Matcher m = match.matcher(string);
             if (m.find())
                 return true;
         }

--- a/src/main/java/eu/endermite/censura/Filter.java
+++ b/src/main/java/eu/endermite/censura/Filter.java
@@ -65,6 +65,13 @@ public class Filter {
         return false;
     }
 
+    public static boolean detect(String message, FilterStrength mode) {
+        return detectPhrases(message, FilterStrength.SEVERE) ||
+                detectPhrases(normalizedString(message), FilterStrength.SEVERE) ||
+                detectPhrases(noRepeatChars(message), FilterStrength.SEVERE) ||
+                detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.SEVERE);
+    }
+
     public static boolean filter(String message, Player player) {
 
         if (player.isOp() && Censura.getCachedConfig().getOpBypass())
@@ -74,63 +81,38 @@ public class Filter {
             return false;
         }
 
-        if (detectPhrases(message, FilterStrength.SEVERE) || detectPhrases(normalizedString(message), FilterStrength.SEVERE)) {
+        if (detect(message, FilterStrength.SEVERE)) {
             doActions(Censura.getCachedConfig().getSeverePunishments(), player);
             return true;
         }
 
-        if (detectPhrases(noRepeatChars(message), FilterStrength.SEVERE) || detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.SEVERE)) {
-            doActions(Censura.getCachedConfig().getSeverePunishments(), player);
-            return true;
-        }
-
-        if (detectPhrases(message, FilterStrength.NORMAL) || detectPhrases(normalizedString(message), FilterStrength.NORMAL)) {
+        if (detect(message, FilterStrength.NORMAL)) {
             doActions(Censura.getCachedConfig().getNormalPunishments(), player);
             return true;
         }
 
-        if (detectPhrases(noRepeatChars(message), FilterStrength.NORMAL) || detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.NORMAL)) {
-            doActions(Censura.getCachedConfig().getNormalPunishments(), player);
-            return true;
-        }
-
-        if (detectPhrases(message, FilterStrength.LITE) || detectPhrases(normalizedString(message), FilterStrength.LITE)) {
+        if (detect(message, FilterStrength.LITE)) {
             doActions(Censura.getCachedConfig().getLitePunishments(), player);
             return true;
         }
 
-        if (detectPhrases(noRepeatChars(message), FilterStrength.LITE) || detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.LITE)) {
-            doActions(Censura.getCachedConfig().getLitePunishments(), player);
-            return true;
-        }
         return false;
     }
 
     public static boolean filterNoActions(String message) {
 
-        if (detectPhrases(message, FilterStrength.SEVERE) || detectPhrases(normalizedString(message), FilterStrength.SEVERE)) {
+        if (detect(message, FilterStrength.SEVERE)) {
             return true;
         }
 
-        if (detectPhrases(noRepeatChars(message), FilterStrength.SEVERE) || detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.SEVERE)) {
+        if (detect(message, FilterStrength.NORMAL)) {
             return true;
         }
 
-        if (detectPhrases(message, FilterStrength.NORMAL) || detectPhrases(normalizedString(message), FilterStrength.NORMAL)) {
+        if (detect(message, FilterStrength.LITE)) {
             return true;
         }
 
-        if (detectPhrases(noRepeatChars(message), FilterStrength.NORMAL) || detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.NORMAL)) {
-            return true;
-        }
-
-        if (detectPhrases(message, FilterStrength.LITE) || detectPhrases(normalizedString(message), FilterStrength.LITE)) {
-            return true;
-        }
-
-        if (detectPhrases(noRepeatChars(message), FilterStrength.LITE) || detectPhrases(noRepeatChars(normalizedString(message)), FilterStrength.LITE)) {
-            return true;
-        }
         return false;
 
     }

--- a/src/main/java/eu/endermite/censura/config/CachedConfig.java
+++ b/src/main/java/eu/endermite/censura/config/CachedConfig.java
@@ -7,19 +7,20 @@ import org.bukkit.configuration.file.FileConfiguration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class CachedConfig {
 
     List<String> liteExceptions = new ArrayList<>();
-    List<String> liteMatches = new ArrayList<>();
+    List<Pattern> liteMatches = new ArrayList<>();
     List<String> litePunishments = new ArrayList<>();
 
     List<String> normalExceptions = new ArrayList<>();
-    List<String> normalMatches = new ArrayList<>();
+    List<Pattern> normalMatches = new ArrayList<>();
     List<String> normalPunishments = new ArrayList<>();
 
     List<String> severeExceptions = new ArrayList<>();
-    List<String> severeMatches = new ArrayList<>();
+    List<Pattern> severeMatches = new ArrayList<>();
     List<String> severePunishments = new ArrayList<>();
 
     List<String> commandsToFilter = new ArrayList<>();
@@ -41,7 +42,7 @@ public class CachedConfig {
         ConfigurationSection liteMatch = lite.getConfigurationSection("match");
 
         for (String liteMatchString : liteMatch.getKeys(false)) {
-            liteMatches.add(liteMatchString);
+            liteMatches.add(Pattern.compile(liteMatchString));
             liteExceptions.addAll(liteMatch.getStringList(liteMatchString + ".exceptions"));
         }
 
@@ -57,7 +58,7 @@ public class CachedConfig {
         ConfigurationSection normalMatch = normal.getConfigurationSection("match");
 
         for (String normalMatchString : normalMatch.getKeys(false)) {
-            normalMatches.add(normalMatchString);
+            normalMatches.add(Pattern.compile(normalMatchString));
             normalExceptions.addAll(normalMatch.getStringList(normalMatchString + ".exceptions"));
         }
 
@@ -73,7 +74,7 @@ public class CachedConfig {
         ConfigurationSection severeMatch = severe.getConfigurationSection("match");
 
         for (String severeMatchString : severeMatch.getKeys(false)) {
-            severeMatches.add(severeMatchString);
+            severeMatches.add(Pattern.compile(severeMatchString));
             severeExceptions.addAll(severeMatch.getStringList(severeMatchString + ".exceptions"));
         }
 
@@ -89,7 +90,7 @@ public class CachedConfig {
 
     }
 
-    public List<String> getLiteMatches() {
+    public List<Pattern> getLiteMatches() {
         return liteMatches;
     }
 
@@ -101,7 +102,7 @@ public class CachedConfig {
         return litePunishments;
     }
 
-    public List<String> getNormalMatches() {
+    public List<Pattern> getNormalMatches() {
         return normalMatches;
     }
 
@@ -113,7 +114,7 @@ public class CachedConfig {
         return normalPunishments;
     }
 
-    public List<String> getSevereMatches() {
+    public List<Pattern> getSevereMatches() {
         return severeMatches;
     }
 


### PR DESCRIPTION
* Replaces `mode` string with enum
* Pre-compiles regex patterns from the config instead of compiling for each check
* Removes code repetition in favour of a single `detect` method 